### PR TITLE
Change OpenTitan to no-assert to override Verilator's change-of-default

### DIFF
--- a/designs/OpenTitan/descriptor.yaml
+++ b/designs/OpenTitan/descriptor.yaml
@@ -667,8 +667,9 @@ compile:
   topModule: chip_sim_tb
   mainClock: chip_sim_tb.clk_i
   verilatorArgs: [
-    --unroll-count, 512,
-    --autoflush
+    --no-assert,
+    --autoflush,
+    --unroll-count, 512
   ]
 
 execute:


### PR DESCRIPTION
Verilator now has `--assert` the default, so get back the OpenTitan loss due to this.