### PR TITLE
Suppress some Verilator warnings to reduce logfile sizes

### DIFF
--- a/designs/BlackParrot/descriptor.yaml
+++ b/designs/BlackParrot/descriptor.yaml
@@ -406,6 +406,11 @@ compile:
     - -Gsim_clock_period_p=10
     - -Gsim_reset_cycles_lo_p=0
     - -Gsim_reset_cycles_hi_p=20
+    - -Wno-ASCRANGE
+    - -Wno-TIMESCALEMOD
+    - -Wno-WIDTHCONCAT
+    - -Wno-WIDTHEXPAND
+    - -Wno-WIDTHTRUNC
 
 execute:
   common:

--- a/designs/Caliptra/descriptor.yaml
+++ b/designs/Caliptra/descriptor.yaml
@@ -661,7 +661,11 @@ compile:
   mainClock: caliptra_top_tb.core_clk
   verilatorArgs: [
     --autoflush,
-    --timescale, 1ns/100ps
+    --timescale, 1ns/100ps,
+    -Wno-ASCRANGE,
+    -Wno-CMPCONST,
+    -Wno-WIDTHEXPAND,
+    -Wno-WIDTHTRUNC
   ]
 
 execute:

--- a/designs/OpenPiton/descriptor.yaml
+++ b/designs/OpenPiton/descriptor.yaml
@@ -298,6 +298,13 @@ compile:
   mainClock: cmp_top.core_ref_clk
   verilatorArgs:
     - --autoflush
+    - -Wno-ASCRANGE
+    - -Wno-CASEINCOMPLETE
+    - -Wno-SELRANGE
+    - -Wno-UNSIGNED
+    - -Wno-WIDTHCONCAT
+    - -Wno-WIDTHEXPAND
+    - -Wno-WIDTHTRUNC
 
 execute:
   common:

--- a/designs/Vortex/descriptor.yaml
+++ b/designs/Vortex/descriptor.yaml
@@ -156,6 +156,10 @@ compile:
   mainClock: tb.clk
   verilatorArgs:
     - --autoflush
+    - -Wno-ASCRANGE
+    - -Wno-UNSIGNED
+    - -Wno-WIDTHEXPAND
+    - -Wno-WIDTHTRUNC
 
 execute:
   common:

--- a/designs/XuanTie-C906/descriptor.yaml
+++ b/designs/XuanTie-C906/descriptor.yaml
@@ -298,7 +298,7 @@ compile:
     - src/uart_ctrl.v
     - src/uart_trans.v
     - src/uart.v
-  verilatorArgs: [ --autoflush ]
+  verilatorArgs: [ --autoflush, -Wno-CASEINCOMPLETE, -Wno-IMPLICIT, -Wno-WIDTHEXPAND, -Wno-WIDTHTRUNC ]
   topModule: tb
   mainClock: tb.clk
 

--- a/designs/XuanTie-C910/descriptor.yaml
+++ b/designs/XuanTie-C910/descriptor.yaml
@@ -474,7 +474,7 @@ compile:
     - src/px_had_sync.v
     - src/sync.v
     - src/tap2_sm.v
-  verilatorArgs: [ --autoflush ]
+  verilatorArgs: [ --autoflush, -Wno-CASEINCOMPLETE, -Wno-IMPLICIT, -Wno-WIDTHEXPAND, -Wno-WIDTHTRUNC ]
   topModule: tb
   mainClock: tb.clk
 

--- a/designs/XuanTie-E902/descriptor.yaml
+++ b/designs/XuanTie-E902/descriptor.yaml
@@ -130,7 +130,7 @@ compile:
     - src/tap2_sm.v
     - src/wic_awake_en_32.v
     - src/wic.v
-  verilatorArgs: [ --autoflush ]
+  verilatorArgs: [ --autoflush, -Wno-CASEINCOMPLETE, -Wno-IMPLICIT, -Wno-WIDTHEXPAND, -Wno-WIDTHTRUNC ]
   topModule: tb
   mainClock: tb.clk
 

--- a/designs/XuanTie-E906/descriptor.yaml
+++ b/designs/XuanTie-E906/descriptor.yaml
@@ -256,7 +256,7 @@ compile:
     - src/wic_top.v
     - src/wic_awake_en_32.v
     - src/wic.v
-  verilatorArgs: [ --autoflush ]
+  verilatorArgs: [ --autoflush, -Wno-CASEINCOMPLETE, -Wno-IMPLICIT, -Wno-WIDTHEXPAND, -Wno-WIDTHTRUNC ]
   topModule: tb
   mainClock: tb.clk
 


### PR DESCRIPTION
It's hard to find errors in the logs as they are long, this disables some of the more harmless warnings (though not all warnings).

BlackParrot will still fail.